### PR TITLE
Added the function get_start_time_for_ema

### DIFF
--- a/backfire/ema.py
+++ b/backfire/ema.py
@@ -140,7 +140,7 @@ def single_backtest(df, bt):
 
     df = ema_logic.set_signals(df, bt)
     # trim results and ignore fills below on our start date:
-    df = df[pd.to_datetime(df.timestamp) > pd.to_datetime(bt.start_date)] 
+    df = df[pd.to_datetime(df.timestamp) >= pd.to_datetime(bt.start_date)] 
     results, my_fills = run_backtest(df, 'both', bt)
     my_fills = fills_running_bal(my_fills, bt)
     results['hodl_roi'] = hodl_roi
@@ -159,6 +159,8 @@ def run_multi(df, my_result_type, bt, my_data):
     bt.set_sell_pct_btc(my_data[5])
     
     df = ema_logic.set_signals(df, bt)
+    # trim results and ignore fills below on our start date:
+    df = df[pd.to_datetime(df.timestamp) >= pd.to_datetime(bt.start_date)] 
     df = df[(df['sell_signal']==1) | (df['buy_signal'] == 1)]
     result = run_backtest(df, my_result_type, bt)
     return(result)

--- a/backfire/ema_multi.py
+++ b/backfire/ema_multi.py
@@ -22,16 +22,27 @@ def backtest_set(raw_data, start_date, end_date):
     bt_vars.set_principle_usd(principle_usd)
     bt_vars.set_principle_btc(principle_btc)
     
-    sell_pcts = [(2 ** x) / 1000 for x in range(4, 11)]
-    sell_pcts = [1 if x > 1 else x for x in sell_pcts]
-    buy_pcts = [(2 ** x) / 1000 for x in range(4, 11)]
-    buy_pcts = [1 if x > 1 else x for x in buy_pcts]
+    pcts = [(2 ** x) / 1000 for x in range(4, 11)]
+    pcts = [1 if x > 1 else x for x in pcts]
+    sell_pcts = pcts
+    buy_pcts = pcts
 
-    upper_windows = [(2 ** x) for x in range(4, 13)]
-    lower_windows = [(2 ** x) for x in range(4, 13)]
-    lower_factor_pcts = [(2 ** x) / 10000 for x in range(5, 10)]
-    upper_factor_pcts = [(2 ** x) / 10000 for x in range(5, 10)]
+    windows = [(2 ** x) for x in range(4, 13)]
+    upper_windows = windows
+    lower_windows = windows
+
+    factor_pcts = [(2 ** x) / 10000 for x in range(5, 10)]
+    lower_factor_pcts = factor_pcts
+    upper_factor_pcts = factor_pcts
     
+    # fix the start time for ema to unfold
+    ema_length = pd.DataFrame(windows).max() #find the biggest window size
+    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_time)
+
+    # prep data
+    day_df, df = ema.prep_data(raw_data, start_date, end_date)
+    df = df[['close', 'timestamp']]
+
     my_result_type = 'backtest'
     start = time.time()
     rois = []

--- a/backfire/ema_multi.py
+++ b/backfire/ema_multi.py
@@ -36,11 +36,11 @@ def backtest_set(raw_data, start_date, end_date):
     upper_factor_pcts = factor_pcts
     
     # fix the start time for ema to unfold
-    ema_length = pd.DataFrame(windows).max() #find the biggest window size
-    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_time)
+    ema_length = int(pd.DataFrame(windows).max()) #find the biggest window size
+    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_date)
 
     # prep data
-    day_df, df = ema.prep_data(raw_data, start_date, end_date)
+    day_df, df = ema.prep_data(raw_data, start_time_fixed, end_date)
     df = df[['close', 'timestamp']]
 
     my_result_type = 'backtest'

--- a/backfire/ema_multi2.py
+++ b/backfire/ema_multi2.py
@@ -9,9 +9,6 @@ import time
 
 # runs the entiry backtets for this set of date with all the possible combinations
 def backtest_set(raw_data, start_date, end_date):
-    day_df, df = ema.prep_data(raw_data, start_date, end_date)
-    df = df[['close', 'timestamp']]
-    
     principle = 35000
     principle_split = principle / 2
     principle_usd = principle # principle_split
@@ -45,6 +42,14 @@ def backtest_set(raw_data, start_date, end_date):
     threshold_hodl_diff = 0.1
     threshold_fills = 5
     
+    # fix the start time for ema to unfold
+    ema_length = pd.DataFrame(windows).max() #find the biggest window size
+    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_time)
+
+    # prep data
+    day_df, df = ema.prep_data(raw_data, start_date, end_date)
+    df = df[['close', 'timestamp']]
+
     my_result_type = 'backtest'
     start = time.time()
     rois = []

--- a/backfire/ema_multi2.py
+++ b/backfire/ema_multi2.py
@@ -29,7 +29,7 @@ def backtest_set(raw_data, start_date, end_date):
 
 #    windows = [10,20,40,60,80,100,140,160,200,300,400,500,600,700,800,1000,2000]
 #    windows = [20,40,60,80,100,150,200,300,400,500,600,700,800]
-    windows = [4,8,12,16,20,25,30,40,50,60,70,80,90,100]
+    windows = [4,8,12,16,20,25,30,40,50,60,70,80,90,100,200,400,600,1000]
     upper_windows = windows
     lower_windows = windows
 
@@ -43,11 +43,11 @@ def backtest_set(raw_data, start_date, end_date):
     threshold_fills = 5
     
     # fix the start time for ema to unfold
-    ema_length = pd.DataFrame(windows).max() #find the biggest window size
-    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_time)
+    ema_length = int(pd.DataFrame(windows).max()) #find the biggest window size
+    start_time_fixed = ema.get_start_time_for_ema(ema_length, start_date)
 
     # prep data
-    day_df, df = ema.prep_data(raw_data, start_date, end_date)
+    day_df, df = ema.prep_data(raw_data, start_time_fixed, end_date)
     df = df[['close', 'timestamp']]
 
     my_result_type = 'backtest'
@@ -89,12 +89,12 @@ def add_vectorized_cols(df, rois_df, bt_vars, start_date, end_date):
 
 
 #raw_data = pd.read_csv('~/backfire/data/resources/coinbase_fixed_2017-01-01_current.csv')
-raw_data = pd.read_csv('~/backfire/data/resources/Bitfinex_BTCUSD_1min_2017-11-20_to_2018-05-30.csv')
+raw_data = pd.read_csv('~/backfire/data/resources/Bitfinex_BTCUSD_1min_2017-11-20_to_2018-06-03.csv')
 #raw_data = pd.read_csv('~/backfire/data/resources/Bitfinex_ETHUSD_1min_2017-12-14_to_2018-05-30.csv')
 
-test_name = 'tobi_BTC_bitfinex_lowN_5months'
-start_date = "2018-01-01"
-end_date = "2018-05-30"
+test_name = 'tobi_BTC_bitfinex_3_days'
+start_date = "2018-06-01"
+end_date = "2018-06-03"
 result_sets = []
 
 rois = backtest_set(raw_data, start_date, end_date)

--- a/backfire/ema_multi2.py
+++ b/backfire/ema_multi2.py
@@ -92,8 +92,8 @@ def add_vectorized_cols(df, rois_df, bt_vars, start_date, end_date):
 raw_data = pd.read_csv('~/backfire/data/resources/Bitfinex_BTCUSD_1min_2017-11-20_to_2018-06-03.csv')
 #raw_data = pd.read_csv('~/backfire/data/resources/Bitfinex_ETHUSD_1min_2017-12-14_to_2018-05-30.csv')
 
-test_name = 'tobi_BTC_bitfinex_3_days'
-start_date = "2018-06-01"
+test_name = 'tobi_BTC_bitfinex_1_day'
+start_date = "2018-06-02"
 end_date = "2018-06-03"
 result_sets = []
 


### PR DESCRIPTION
Its purpose is to get the correct start time in the past so the
ema can unfold before we actually run the test. Thus eliminating
faulty results at the start of our test.

additionaly the fills output is cut again by the original start_time
to prevent trades older then our start date.

Also addes variables to the BacktestSettings class for start and end date.